### PR TITLE
Fix rxjs dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,8 +57,10 @@
 		"json2typescript": "^1.0.5",
 		"jsonic": "^0.3.0",
 		"node-fetch": "^2.1.2",
-		"rxjs": "^5.5.2",
 		"signalr-client": "0.0.17"
+	},
+	"peerDependencies": {
+		"rxjs": "^5.5.2"
 	},
 	"devDependencies": {
 		"@types/jest": "22.2.3",
@@ -67,6 +69,7 @@
 		"dotenv": "5.0.1",
 		"jest": "22.4.3",
 		"jest-cli": "22.4.3",
+		"rxjs": "^5.5.2",
 		"ts-jest": "22.4.4",
 		"ts-node": "6.0.1",
 		"tslint": "5.9.1",


### PR DESCRIPTION
This pull request moves rxjs dependency to peerDependencies and devDependencies to avoid type conflicts when application depends on newest version of rxjs.